### PR TITLE
Store properties in Email+ template as an object.

### DIFF
--- a/src/Seq.App.EmailPlus/EmailReactor.cs
+++ b/src/Seq.App.EmailPlus/EmailReactor.cs
@@ -109,10 +109,6 @@ namespace Seq.App.EmailPlus
 
         string FormatTemplate(Func<object, string> template, Event<LogEventData> evt)
         {
-            var properties = evt.Data.Properties
-                .Select(prop => new {Name = prop.Key, Value = ToDynamic(prop.Value)})
-                .ToArray();
-
             var payload = ToDynamic(new Dictionary<string, object>
             {
                 { "$Id",                  evt.Id },
@@ -122,7 +118,7 @@ namespace Seq.App.EmailPlus
                 { "$MessageTemplate",     evt.Data.MessageTemplate },
                 { "$Message",             evt.Data.RenderedMessage },
                 { "$Exception",           evt.Data.Exception },
-                { "$Properties",          properties },
+                { "$Properties",          ToDynamic(evt.Data.Properties) },
                 { "$EventType",           "$" + evt.EventType.ToString("X8") },
                 { "$Instance",            base.Host.InstanceName },
                 { "$ServerUri",           base.Host.ListenUris.FirstOrDefault() }

--- a/src/Seq.App.EmailPlus/Resources/DefaultBodyTemplate.html
+++ b/src/Seq.App.EmailPlus/Resources/DefaultBodyTemplate.html
@@ -141,8 +141,8 @@
                 <div class="seq-event-properties" style="margin-top:5px;">
                     {{#each $Properties}}
                     <div class="seq-event-property">
-                        <div class="seq-property-name" title="{{Name}}" style="float:left;width:200px;overflow:hidden;font-family:monospace;font-size:13px;font-weight:bold;text-overflow:ellipsis;">{{Name}}</div>
-                        <div class="seq-property-value" style="margin-left:245px;font-family:monospace;font-size:13px;word-wrap:break-word;white-space:pre-wrap;">{{pretty Value}}</div>
+                        <div class="seq-property-name" title="{{@key}}" style="float:left;width:200px;overflow:hidden;font-family:monospace;font-size:13px;font-weight:bold;text-overflow:ellipsis;">{{@key}}</div>
+                        <div class="seq-property-value" style="margin-left:245px;font-family:monospace;font-size:13px;word-wrap:break-word;white-space:pre-wrap;">{{pretty this}}</div>
                     </div>
                     {{/each}}
                     {{#if $Exception}}

--- a/src/Seq.App.EmailPlus/Resources/RawBodyTemplate.html
+++ b/src/Seq.App.EmailPlus/Resources/RawBodyTemplate.html
@@ -144,8 +144,8 @@
                 <div class="seq-event-properties">
                     {{#each $Properties}}
                     <div class="seq-event-property">
-                        <div class="seq-property-name" title="{{Name}}">{{Name}}</div>
-                        <div class="seq-property-value">{{pretty Value}}</div>
+                        <div class="seq-property-name" title="{{@key}}">{{@key}}</div>
+                        <div class="seq-property-value">{{pretty this}}</div>
                     </div>
                     {{/each}}
                     {{#if $Exception}}

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Handlebars">
-      <HintPath>..\..\packages\Handlebars.Net.1.0.2\lib\Handlebars.dll</HintPath>
+    <Reference Include="Handlebars, Version=1.0.5542.36571, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Handlebars.Net.1.2.9\lib\Handlebars.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -32,8 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Handlebars, Version=1.0.5542.36571, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Handlebars">
       <HintPath>..\..\packages\Handlebars.Net.1.2.9\lib\Handlebars.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/Seq.App.EmailPlus/packages.config
+++ b/src/Seq.App.EmailPlus/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Handlebars.Net" version="1.0.2" targetFramework="net45" />
+  <package id="Handlebars.Net" version="1.2.9" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Seq.Apps" version="1.6.4" targetFramework="net45" />
   <package id="Serilog" version="1.4.113" targetFramework="net45" />


### PR DESCRIPTION
This will allow easy access to properties in templates using dot paths like $Properties.Foo.
Iteration of all properties works with Handlebars' object iteration.
Requires at least version 1.2.9 of Handlebars.Net because of some dynamic iteration fixes in that version.