### PR TITLE
Produce at most N threshold reached messages when {Threshold} * N messages are received

### DIFF
--- a/seq-apps.sln
+++ b/seq-apps.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.App.EmailPlus", "src\Se
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.App.EmailPlus.Tests", "test\Seq.App.EmailPlus.Tests\Seq.App.EmailPlus.Tests.csproj", "{C451A1B4-A053-4E43-B97C-C3D3A0F82CC5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.App.Thresholds.Tests", "test\Seq.App.Thresholds.Tests\Seq.App.Thresholds.Tests.csproj", "{BAED4BF3-FDEB-49F7-BAEF-05CB0E8C92CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{C451A1B4-A053-4E43-B97C-C3D3A0F82CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C451A1B4-A053-4E43-B97C-C3D3A0F82CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C451A1B4-A053-4E43-B97C-C3D3A0F82CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BAED4BF3-FDEB-49F7-BAEF-05CB0E8C92CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAED4BF3-FDEB-49F7-BAEF-05CB0E8C92CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAED4BF3-FDEB-49F7-BAEF-05CB0E8C92CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAED4BF3-FDEB-49F7-BAEF-05CB0E8C92CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -72,5 +78,6 @@ Global
 		{BBF8EFB1-BAEA-40A8-A7AC-30C81C45FEA0} = {3FC57D53-9F60-4FAB-AFD8-8CB23EE3B9D9}
 		{35ABF152-CDE5-4E8A-86AA-5E47CBAAD9F9} = {3FC57D53-9F60-4FAB-AFD8-8CB23EE3B9D9}
 		{C451A1B4-A053-4E43-B97C-C3D3A0F82CC5} = {775EF423-0A25-485A-BFA0-BAE59F580C9A}
+		{BAED4BF3-FDEB-49F7-BAEF-05CB0E8C92CF} = {775EF423-0A25-485A-BFA0-BAE59F580C9A}
 	EndGlobalSection
 EndGlobal

--- a/src/Seq.App.Thresholds/ThresholdReactor.cs
+++ b/src/Seq.App.Thresholds/ThresholdReactor.cs
@@ -119,33 +119,17 @@ namespace Seq.App.Thresholds
                 var firstReused = (_currentBucket + 1) % _buckets.Length;
                 if (distance >= _buckets.Length)
                 {
-                    _sum = 0;
-                    for (var i = 0; i < _buckets.Length; i++)
-                    {
-                        _buckets[i] = 0;
-                    }
+                    ResetSum();
                 }
                 else if (newCurrent >= firstReused)
                 {
-                    for (var i = firstReused; i <= newCurrent; i++)
-                    {
-                        _sum -= _buckets[i];
-                        _buckets[i] = 0;
-                    }
+                    CleanupBuckets(firstReused, newCurrent);
                 }
                 else
                 {
-                    for (var i = firstReused; i < _buckets.Length; i++)
-                    {
-                        _sum -= _buckets[i];
-                        _buckets[i] = 0;
-                    }
+                    CleanupBuckets(firstReused, _buckets.Length - 1);
 
-                    for (var i = 0; i <= newCurrent; i++)
-                    {
-                        _sum -= _buckets[i];
-                        _buckets[i] = 0;
-                    }
+                    CleanupBuckets(0, newCurrent);
                 }
 
                 _currentBucket = newCurrent;
@@ -154,6 +138,15 @@ namespace Seq.App.Thresholds
 
             eventBucket = _currentBucket;
             return true;
+        }
+
+        private void CleanupBuckets(int firstReused, int lastReused)
+        {
+            for (var i = firstReused; i <= lastReused; i++)
+            {
+                _sum -= _buckets[i];
+                _buckets[i] = 0;
+            }
         }
 
         // Check the current suppression time

--- a/src/Seq.App.Thresholds/ThresholdReactor.cs
+++ b/src/Seq.App.Thresholds/ThresholdReactor.cs
@@ -83,6 +83,14 @@ namespace Seq.App.Thresholds
             _suppressUntilUtc = DateTime.UtcNow + _suppressionTime;
             Log.Information("Threshold {ThresholdName} reached: {EventCount} events observed within {WindowSize} sec. (message suppressed for {SuppressionSeconds} sec.)",
                 ThresholdName, _sum, _buckets.Length, (int)_suppressionTime.TotalSeconds);
+
+            ResetSum();
+        }
+
+        private void ResetSum()
+        {
+            _sum = 0;
+            Array.Clear(_buckets, 0, _buckets.Length);
         }
 
         // Adjusts the window to fit the event, providing the index into

--- a/src/Seq.App.Thresholds/ThresholdReactor.cs
+++ b/src/Seq.App.Thresholds/ThresholdReactor.cs
@@ -53,6 +53,11 @@ namespace Seq.App.Thresholds
             HelpText = "The name of this threshold; the events written back to the stream will be tagged with this value.")]
         public string ThresholdName { get; set; }
 
+        [SeqAppSetting(
+            DisplayName = "Reset on threshold reached",
+            HelpText = "Once the threshold is reached, reset the event count so that threshold must be reached again before another event is triggered.")]
+        public bool ResetOnThresholdReached { get; set; }
+
         // Sets up the sliding buffer when the app starts
         protected override void OnAttached()
         {
@@ -84,7 +89,10 @@ namespace Seq.App.Thresholds
             Log.Information("Threshold {ThresholdName} reached: {EventCount} events observed within {WindowSize} sec. (message suppressed for {SuppressionSeconds} sec.)",
                 ThresholdName, _sum, _buckets.Length, (int)_suppressionTime.TotalSeconds);
 
-            ResetSum();
+            if (ResetOnThresholdReached)
+            {
+                ResetSum();
+            }
         }
 
         private void ResetSum()

--- a/test/Seq.App.Thresholds.Tests/Properties/AssemblyInfo.cs
+++ b/test/Seq.App.Thresholds.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Seq.App.Thresholds.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Seq.App.Thresholds.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7333f0e5-7ec1-4eb8-97d4-9cad8a450e93")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/Seq.App.Thresholds.Tests/Seq.App.Thresholds.Tests.csproj
+++ b/test/Seq.App.Thresholds.Tests/Seq.App.Thresholds.Tests.csproj
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BAED4BF3-FDEB-49F7-BAEF-05CB0E8C92CF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Seq.App.Thresholds.Tests</RootNamespace>
+    <AssemblyName>Seq.App.Thresholds.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Seq.Apps, Version=1.6.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Seq.Apps.1.6.4\lib\net45\Seq.Apps.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.11\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.11\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Support\Some.cs" />
+    <Compile Include="ThresholdReactorTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Seq.App.Thresholds\Seq.App.Thresholds.csproj">
+      <Project>{715102FE-A617-4FEA-A8B6-01CDB866EE91}</Project>
+      <Name>Seq.App.Thresholds</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/Seq.App.Thresholds.Tests/Support/Some.cs
+++ b/test/Seq.App.Thresholds.Tests/Support/Some.cs
@@ -23,10 +23,15 @@ namespace Seq.App.Thresholds.Tests.Support
             return Uint();
         }
 
-        public static Event<LogEventData> LogEvent(IDictionary<string, object> includedProperties = null)
+        public static Event<LogEventData> LogEvent(IDictionary<string, object> includedProperties = null, DateTime timestamp = default(DateTime))
         {
             var id = EventId();
-            var timestamp = UtcTimestamp();
+
+            if (timestamp == default(DateTime))
+            {
+                timestamp = UtcTimestamp();
+            }
+
             var properties = new Dictionary<string, object>
             {
                 {"Who", "world"},

--- a/test/Seq.App.Thresholds.Tests/Support/Some.cs
+++ b/test/Seq.App.Thresholds.Tests/Support/Some.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+
+namespace Seq.App.Thresholds.Tests.Support
+{
+    public static class Some
+    {
+        public static string String()
+        {
+            return Guid.NewGuid().ToString();
+        }
+
+        public static uint Uint()
+        {
+            return 5417u;
+        }
+
+        public static uint EventType()
+        {
+            return Uint();
+        }
+
+        public static Event<LogEventData> LogEvent(IDictionary<string, object> includedProperties = null)
+        {
+            var id = EventId();
+            var timestamp = UtcTimestamp();
+            var properties = new Dictionary<string, object>
+            {
+                {"Who", "world"},
+                {"Number", 42}
+            };
+
+            if (includedProperties != null)
+            {
+                foreach (var includedProperty in includedProperties)
+                {
+                    properties.Add(includedProperty.Key, includedProperty.Value);
+                }
+            }
+
+            return new Event<LogEventData>(id, EventType(), timestamp, new LogEventData
+            {
+                Exception = null,
+                Id = id,
+                Level = LogEventLevel.Fatal,
+                LocalTimestamp = new DateTimeOffset(timestamp),
+                MessageTemplate = "Hello, {Who}",
+                RenderedMessage = "Hello, world",
+                Properties = properties
+            });
+        }
+
+        public static string EventId()
+        {
+            return "event-" + String();
+        }
+
+        public static DateTime UtcTimestamp()
+        {
+            return DateTime.UtcNow;
+        }
+
+        public static string Uri()
+        {
+            return "https://" + String();
+        }
+
+        public static Host Host()
+        {
+            return new Host(new [] { Uri() }, String() );
+        }
+    }
+}

--- a/test/Seq.App.Thresholds.Tests/ThresholdReactorTests.cs
+++ b/test/Seq.App.Thresholds.Tests/ThresholdReactorTests.cs
@@ -71,6 +71,22 @@ namespace Seq.App.Thresholds.Tests
         }
 
         [Test]
+        public void when_reset_disabled_and_threshold_exceeded_should_only_3_message()
+        {
+            const int ExpectLogs = 3;
+            const int SecondsBetweenLogs = 0;
+
+            // arrange
+            var sut = GetThresholdReactor(5, false);
+
+            // act
+            SendXEventsNSecondsApart(sut, 7, SecondsBetweenLogs);
+
+            // assert
+            _logger.Verify(l => l.Information(It.IsAny<string>(), It.IsAny<object[]>()), Times.Exactly(ExpectLogs));
+        }
+
+        [Test]
         public void when_threshold_tripled_over_time_should_get_3_logs()
         {
             const int ExpectLogs = 3;
@@ -110,13 +126,14 @@ namespace Seq.App.Thresholds.Tests
             }
         }
 
-        private ThresholdReactor GetThresholdReactor(int threshold)
+        private ThresholdReactor GetThresholdReactor(int threshold, bool resetOnThresholdReached = true)
         {
             var sut = new ThresholdReactor()
                 {
                     EventsInWindowThreshold = threshold, 
                     ThresholdName = Guid.NewGuid().ToString(), 
-                    WindowSeconds = 120
+                    WindowSeconds = 120,
+                    ResetOnThresholdReached = resetOnThresholdReached
                 };
 
             var appHost = new Mock<IAppHost>();

--- a/test/Seq.App.Thresholds.Tests/ThresholdReactorTests.cs
+++ b/test/Seq.App.Thresholds.Tests/ThresholdReactorTests.cs
@@ -16,13 +16,11 @@ namespace Seq.App.Thresholds.Tests
     public class ThresholdReactorTests
     {
         private Mock<ILogger> _logger;
-        private DateTime _testStartTime;
 
         [SetUp]
         public void SetUp()
         {
             _logger = new Mock<ILogger>();
-            _testStartTime = Some.UtcTimestamp();
         }
 
         [Test]
@@ -71,7 +69,7 @@ namespace Seq.App.Thresholds.Tests
         }
 
         [Test]
-        public void when_reset_disabled_and_threshold_exceeded_should_only_3_message()
+        public void when_reset_disabled_and_threshold_exceeded_should_log_only_3_message()
         {
             const int ExpectLogs = 3;
             const int SecondsBetweenLogs = 0;
@@ -118,9 +116,11 @@ namespace Seq.App.Thresholds.Tests
 
         private void SendXEventsNSecondsApart(ISubscribeTo<LogEventData> sut, int numberOfEvents, int secondsBetweenEvents = 0)
         {
+            var firstEventTime = Some.UtcTimestamp();
+
             for (var i = 0; i < numberOfEvents; i++)
             {
-                var eventTime = _testStartTime + TimeSpan.FromSeconds(i * secondsBetweenEvents);
+                var eventTime = firstEventTime + TimeSpan.FromSeconds(i * secondsBetweenEvents);
                 var @event = Some.LogEvent(timestamp: eventTime);
                 sut.On(@event);
             }

--- a/test/Seq.App.Thresholds.Tests/ThresholdReactorTests.cs
+++ b/test/Seq.App.Thresholds.Tests/ThresholdReactorTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Seq.App.Thresholds;
+
+using NUnit.Framework;
+using Moq;
+
+using Seq.App.Thresholds.Tests.Support;
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+
+using Serilog;
+
+namespace Seq.App.Thresholds.Tests
+{
+    [TestFixture]
+    public class ThresholdReactorTests
+    {
+        private Mock<ILogger> _logger; 
+
+        [Test]
+        public void when_threshold_exceeded_only_one_message_should_be_logged()
+        {
+            // arrange
+            var sut = new ThresholdReactor()
+            {
+                EventsInWindowThreshold = 5, 
+                ThresholdName = Guid.NewGuid().ToString(), 
+                WindowSeconds = 20
+            };
+
+            _logger = new Mock<ILogger>();
+
+            var appHost = new Mock<IAppHost>();
+            appHost.SetupGet(h => h.Host).Returns(new Host(new[] { "localhost" }, "test"));
+            appHost.SetupGet(h => h.Logger).Returns(_logger.Object);
+
+            sut.Attach(appHost.Object);
+            
+            // act
+            SendEvents(sut, 7);
+
+            // assert
+            _logger.Verify(l => l.Information(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once());
+        }
+
+        private static void SendEvents(ISubscribeTo<LogEventData> sut, int numberOfEvents)
+        {
+            for (var i = 0; i < numberOfEvents; i++)
+            {
+                sut.On(Some.LogEvent());
+            }
+        }
+    }
+}

--- a/test/Seq.App.Thresholds.Tests/ThresholdReactorTests.cs
+++ b/test/Seq.App.Thresholds.Tests/ThresholdReactorTests.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-using Seq.App.Thresholds;
+using Moq;
 
 using NUnit.Framework;
-using Moq;
 
 using Seq.App.Thresholds.Tests.Support;
 using Seq.Apps;
@@ -20,40 +15,117 @@ namespace Seq.App.Thresholds.Tests
     [TestFixture]
     public class ThresholdReactorTests
     {
-        private Mock<ILogger> _logger; 
+        private Mock<ILogger> _logger;
+        private DateTime _testStartTime;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _logger = new Mock<ILogger>();
+            _testStartTime = Some.UtcTimestamp();
+        }
 
         [Test]
-        public void when_threshold_exceeded_only_one_message_should_be_logged()
+        public void when_wrapped_before_threshold_reached_should_not_log()
         {
-            // arrange
-            var sut = new ThresholdReactor()
-            {
-                EventsInWindowThreshold = 5, 
-                ThresholdName = Guid.NewGuid().ToString(), 
-                WindowSeconds = 20
-            };
+            const int SecondsBetweenLogs = 45;
 
-            _logger = new Mock<ILogger>();
+            // arrange
+            var sut = GetThresholdReactor(5);
+
+            // act
+            SendXEventsNSecondsApart(sut, 7, SecondsBetweenLogs);
+
+            // assert
+            _logger.Verify(l => l.Information(It.IsAny<string>(), It.IsAny<object[]>()), Times.Never);
+        }
+
+        [Test]
+        public void when_threshold_exceeded_over_time_should_log_only_1_message()
+        {
+            const int SecondsBetweenLogs = 2;
+
+            // arrange
+            var sut = GetThresholdReactor(5);
+
+            // act
+            SendXEventsNSecondsApart(sut, 7, SecondsBetweenLogs);
+
+            // assert
+            _logger.Verify(l => l.Information(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once());
+        }
+
+        [Test]
+        public void when_threshold_exceeded_should_log_only_1_message()
+        {
+            const int SecondsBetweenLogs = 0;
+
+            // arrange
+            var sut = GetThresholdReactor(5);
+
+            // act
+            SendXEventsNSecondsApart(sut, 7, SecondsBetweenLogs);
+
+            // assert
+            _logger.Verify(l => l.Information(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once());
+        }
+
+        [Test]
+        public void when_threshold_tripled_over_time_should_get_3_logs()
+        {
+            const int ExpectLogs = 3;
+            const int Threshold = 5;
+            const int SecondsBetweenLogs = 2;
+            var sut = GetThresholdReactor(Threshold);
+
+            // act
+            SendXEventsNSecondsApart(sut, Threshold * ExpectLogs, SecondsBetweenLogs);
+
+            // assert
+            _logger.Verify(l => l.Information(It.IsAny<string>(), It.IsAny<object[]>()), Times.Exactly(ExpectLogs));
+        }
+
+        [Test]
+        public void when_threshold_tripled_should_get_3_logs()
+        {
+            const int ExpectLogs = 3;
+            const int Threshold = 5;
+            const int SecondsBetweenLogs = 2;
+            var sut = GetThresholdReactor(Threshold);
+
+            // act
+            SendXEventsNSecondsApart(sut, Threshold * ExpectLogs, SecondsBetweenLogs);
+
+            // assert
+            _logger.Verify(l => l.Information(It.IsAny<string>(), It.IsAny<object[]>()), Times.Exactly(ExpectLogs));
+        }
+
+        private void SendXEventsNSecondsApart(ISubscribeTo<LogEventData> sut, int numberOfEvents, int secondsBetweenEvents = 0)
+        {
+            for (var i = 0; i < numberOfEvents; i++)
+            {
+                var eventTime = _testStartTime + TimeSpan.FromSeconds(i * secondsBetweenEvents);
+                var @event = Some.LogEvent(timestamp: eventTime);
+                sut.On(@event);
+            }
+        }
+
+        private ThresholdReactor GetThresholdReactor(int threshold)
+        {
+            var sut = new ThresholdReactor()
+                {
+                    EventsInWindowThreshold = threshold, 
+                    ThresholdName = Guid.NewGuid().ToString(), 
+                    WindowSeconds = 120
+                };
 
             var appHost = new Mock<IAppHost>();
             appHost.SetupGet(h => h.Host).Returns(new Host(new[] { "localhost" }, "test"));
             appHost.SetupGet(h => h.Logger).Returns(_logger.Object);
 
             sut.Attach(appHost.Object);
-            
-            // act
-            SendEvents(sut, 7);
 
-            // assert
-            _logger.Verify(l => l.Information(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once());
-        }
-
-        private static void SendEvents(ISubscribeTo<LogEventData> sut, int numberOfEvents)
-        {
-            for (var i = 0; i < numberOfEvents; i++)
-            {
-                sut.On(Some.LogEvent());
-            }
+            return sut;
         }
     }
 }

--- a/test/Seq.App.Thresholds.Tests/app.config
+++ b/test/Seq.App.Thresholds.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/Seq.App.Thresholds.Tests/packages.config
+++ b/test/Seq.App.Thresholds.Tests/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="Seq.Apps" version="1.6.4" targetFramework="net45" />
+  <package id="Serilog" version="1.5.11" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This introduces a change in behavior in commit 5802dd47c2e6b738fd1e575352e3531e93eac3b2. 

## Previous behavior: "Reset on threshold reached"=false:
When threshold is reached, all messages exceeding the threshold will log a threshold reached message until the count is reduced by the passing of time.  Given a constant stream of log messages at a high enough rate, every message will produce a threshold reached message.

## New behavior: "Reset on threshold reached"=true:
When threshold is reached, after a threshold reach message is logged, the counters will be reset.  Threshold must be reached again before another threshold reached message is logged. Given a threshold of N, a threshold reached message will be logged at most every N messages.

## Other changes: 
* Added tests around ThresholdReactor to document its behavior in 48594ee9c3f4d0b1b4b73852a7ab852fcb2fa459 and 69a13dbdf76c9838f4e6f1d5aec86cd60319e0f7
* Reduced some duplication in ThresholdReactor in 09c91c5e360104b27a509d840aa462203c7a63eb